### PR TITLE
Add GPU skip mark

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import importlib
+import pytest
+
+skip_gpu = pytest.mark.skipif(importlib.util.find_spec("cupy") is None, reason="CuPy not available")


### PR DESCRIPTION
## Summary
- add a tests configuration file that defines `skip_gpu`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python -m pytest -q` *(fails: No module named pytest)*